### PR TITLE
Public 配送先登録/一覧表示/編集機能の追加

### DIFF
--- a/app/controllers/public/shipping_addresses_controller.rb
+++ b/app/controllers/public/shipping_addresses_controller.rb
@@ -1,20 +1,36 @@
 class Public::ShippingAddressesController < ApplicationController
-    
-    
-def index
-end
 
-def edit
-end
+  def index
+    @shipping_addresses=ShippingAddress.all
+    @shipping_address=ShippingAddress.new
+  end
 
-def create
-end
+  def edit
+    @shipping_address=ShippingAddress.find(params[:id])
+  end
 
-def update
-end
+  def create
+    @shipping_address=ShippingAddress.new(shipping_address_params)
+    @shipping_address.save
+    redirect_to shipping_addresses_path
+  end
 
-def destroy
-end
+  def update
+    @shipping_address=ShippingAddress.find(params[:id])
+    @shipping_address.update(shipping_address_params)
+    redirect_to shipping_addresses_path
+  end
 
+  def destroy
+    @shipping_address=ShippingAddress.find(params[:id])
+    @shipping_address.destroy
+    redirect_to shipping_addresses_path
+  end
+
+  private
+
+  def shipping_address_params
+    params.require(:shipping_address).permit(:postal_code, :address, :address_name)
+  end
 
 end

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,0 +1,2 @@
+class ShippingAddress < ApplicationRecord
+end

--- a/app/views/public/shipping_addresses/edit.html.erb
+++ b/app/views/public/shipping_addresses/edit.html.erb
@@ -1,0 +1,42 @@
+
+<div class="col-2 offset-1 mb-5 bg-light text-black">
+  <h3>配送先編集</h3>
+</div>
+
+<div class="container-fluid">
+  <%= form_with model: @shipping_address do |f| %>
+    <div class="form-group">
+      <div class="row mb-2 ml-5">
+        <div class="col-2">
+          <label for="InputPostalCode">郵便番号（ハイフンなし）</label>
+        </div>
+        <div class="col">
+          <%= f.text_field :postal_code, size: 40, placeholder: "0000000" %>
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="row mb-2 ml-5">
+        <div class="col-2">
+          <label for="InputAddress">住所</label>
+        </div>
+        <div class="col">
+          <%= f.text_field :address, size: 90, placeholder: "東京都渋谷区代々木神園町0-0" %>
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="row mb-5 ml-5">
+        <div class="col-2">
+          <label for="InputAddressName">宛名</label>
+        </div>
+        <div class="col-3">
+          <%= f.text_field :address_name, size: 40, placeholder: "令和道子" %>
+        </div>
+        <div class="col-2 offset-3">
+          <%= f.submit "変更内容を保存", class: "btn btn-success btn-block" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/public/shipping_addresses/index.html.erb
+++ b/app/views/public/shipping_addresses/index.html.erb
@@ -1,0 +1,68 @@
+
+<div class="col-2 offset-1 mb-5 bg-light text-black">
+  <h3>配送先登録 / 一覧</h3>
+</div>
+
+<div class="container-fluid">
+  <%= form_with model: @shipping_address do |f| %>
+    <div class="form-group">
+      <div class="row mb-2 ml-5">
+        <div class="col-2">
+          <label for="InputPostalCode">郵便番号（ハイフンなし）</label>
+        </div>
+        <div class="col">
+          <%= f.text_field :postal_code, size: 40, placeholder: "0000000" %>
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="row mb-2 ml-5">
+        <div class="col-2">
+          <label for="InputAddress">住所</label>
+        </div>
+        <div class="col">
+          <%= f.text_field :address, size: 90, placeholder: "東京都渋谷区代々木神園町0-0" %>
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="row mb-5 ml-5">
+        <div class="col-2">
+          <label for="InputAddressName">宛名</label>
+        </div>
+        <div class="col-3">
+          <%= f.text_field :address_name, size: 40, placeholder: "令和道子" %>
+        </div>
+        <div class="col-2 offset-3">
+          <%= f.submit "新規登録", class: "btn btn-success btn-block" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<div class="w-75 ml-5">
+  <table class="table table-bordered">
+    <thead>
+      <tr class="table-secondary">
+        <th scope="col" style="width: 15%">郵便番号</th>
+        <th scope="col" style="width: 35%">住所</th>
+        <th scope="col" style="width: 20%">宛名</th>
+        <th scope="col" style="width: 30%"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @shipping_addresses.each do |shipping_address| %>
+      <tr>
+        <td><%= shipping_address.postal_code %></td>
+        <td><%= shipping_address.address %></td>
+        <td><%= shipping_address.address_name %></td>
+        <td class="text-center">
+          <%= link_to "編集する", edit_shipping_address_path(shipping_address.id), class: "btn btn-success" %>
+          <%= link_to "削除する", shipping_address_path(shipping_address), class: "btn btn-danger", method: :delete %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/db/migrate/20230117235931_create_shipping_addresses.rb
+++ b/db/migrate/20230117235931_create_shipping_addresses.rb
@@ -1,0 +1,10 @@
+class CreateShippingAddresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :shipping_addresses do |t|
+      t.string :address_name
+      t.string :postal_code
+      t.string :address
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_17_053721) do
+ActiveRecord::Schema.define(version: 2023_01_17_235931) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -70,6 +70,14 @@ ActiveRecord::Schema.define(version: 2023_01_17_053721) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
+  end
+
+  create_table "shipping_addresses", force: :cascade do |t|
+    t.string "address_name"
+    t.string "postal_code"
+    t.string "address"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/fixtures/shipping_addresses.yml
+++ b/test/fixtures/shipping_addresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/shipping_address_test.rb
+++ b/test/models/shipping_address_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ShippingAddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Publicの配送先登録/一覧表示/編集機能を追加しました。
レイアウト済みです。
※バリデーションやフラッシュメッセージは実装していません。

（主な変更）
ShippingAddressモデルの作成
shipping_addressesコントローラーへ記述
shipping_addressesのindexとeditのビューへ記述