### PR TITLE
注文、注文詳細一覧機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'kaminari','~> 1.2.1'
 gem 'enum_help'
+gem 'devise-i18n'
+
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.10.2)
+      devise (>= 4.8.0)
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
     erubi (1.12.0)
@@ -256,6 +258,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   devise
+  devise-i18n
   enum_help
   image_processing (~> 1.2)
   jbuilder (~> 2.7)

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -2,15 +2,36 @@ class Public::OrdersController < ApplicationController
     
     
 def new
+    @order = Order.new
+    @shipping_addresses = ShippingAddress.where(customer: current_customer)
 end
 
 def index
+     @orders = Order.all
 end
 
 def show
+    @order = Order.find(params[:id])
 end
 
 def create
+    #cart_items = current_customer.cart_items.all
+     @order = current_customer.orders.new(order_params)
+    if @order.save
+         cart_items.each do |cart|
+             order_item = OrderItem.new
+             #order_item.item_id = cart.item_id
+             order_item.order_id = @order.id
+             #order_item.order_quantity = cart.quantity
+             #order_item.order_price = cart.item.price
+             order_item.save
+    end
+     redirect_to "/orders/thanx"
+     cart_items.destroy_all
+    else
+     @order = Order.new(order_params)
+     render :new
+    end
 end 
 
 def log 
@@ -18,5 +39,11 @@ end
 
 def thanx
 end 
+  def order_params
+    params.require(:order).permit(:postal_code, :address, :name, :payment_method, :total_price)
+  end
 
+  def address_params
+    params.require(:order).permit(:postal_code, :address, :name)
+  end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,6 +1,10 @@
 class Customer < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :shipping_addresses
+  #has_many :cart_items
+  has_many :orders
+  
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
          

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,6 @@
+class Order < ApplicationRecord
+belongs_to :customer
+has_many :order_items
+    
+enum payment_method: { credit_card: 0, transfer: 1 }
+end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,0 +1,6 @@
+class OrderItem < ApplicationRecord
+belongs_to :order
+#belongs_to :item
+    
+    
+end

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,2 +1,4 @@
 class ShippingAddress < ApplicationRecord
+    belongs_to :customer
+    
 end

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -1,0 +1,47 @@
+<h1>注文履歴一覧</h1>
+<div calss="row">
+  <div class="col-xs-12">
+    <h2 class="text-center">注文履歴一覧</h2>
+      <% if @orders.present? %>
+        <table>
+          <thead>
+            <tr class="info">
+              <th><i class="fas fa-calendar-day"></i>注文日</th>
+              <th>配送先</th>
+              <th>注文商品</th>
+              <th>支払金額</th>
+              <th>ステータス</th>
+              <th>注文詳細</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @orders.each do |order| %>
+              <tr>
+                <td>
+    		    <%= order.created_at.strftime('%Y/%m/%d') %>
+    		    </td>
+    		    <td class="text-left">
+    		    <%= order.postal_code %><br>
+    		    <%= order.address %><br>
+    		    <%= order.name %>
+    		    </td>
+    		    <td>
+    		    <% order.order_details.each do |order_detail| %>
+    		    <%= order_detail.product.name %><br>
+    		    <% end %>
+    		    </td>
+    		    <td class="text-right">
+    		    <%= order.total_price.to_s(:delimited) %>円
+    		    </td>
+         	    <td>
+       	        <%= link_to "注文詳細", customers_order_path(order), class: "glyphicon glyphicon-zoom-in btn btn-success" %>
+       	        </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p>注文履歴がありません。</p>
+      <% end %>
+    </div>
+</div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -1,0 +1,57 @@
+<h1>注文</h1>
+
+<div class="row">
+  <div class="col-xs-12">
+  <h2 class="head-line title_h2 text-center">注文情報入力</h2>
+      <%= form_with :model => @order,method: :post, local: true  do |f| %>
+        <h3 class="col-xs-3 sub-head text-center"><i class="fas fa-yen-sign"></i>支払い方法</h3>
+          <div class="col-xs-10 radio">
+            <%= f.radio_button :payment_method, :"クレジットカード", checked: true %>
+            <span>クレジットカード</span>
+          </div>
+          <div class="col-xs-10 radio">
+            <%= f.radio_button :payment_method, :"銀行振込" %>
+            <span>銀行振り込み</span>
+          </div>
+          </div>
+           
+
+        <h3 class="col-xs-3 sub-head text-center"><i class="fas fa-people-carry"></i>お届け先</h3>
+          <div class="col-xs-10 radio">
+            <%= f.radio_button :addresses, "registrations", checked: true  %>
+            <span>ご自身の住所</span><br>
+            
+          </div>
+
+          
+          <div class="col-xs-10 radio">
+            <%= f.radio_button :addresses, "shipping_addresses" %>
+              <span>登録済住所から選択</span><br>
+          </div>
+         
+
+          <div class="new-address col-xs-10 radio">
+            <%= f.radio_button :addresses, "new_address" %>
+            <span>新しいお届け先</span><br>
+            <div class="field form-group col-xs-11">
+              <%= f.label :"郵便番号(ハイフンなし)" %>
+              <%= f.text_field :postal_code %>
+            </div>
+            <div class="field form-group col-xs-11">
+              <%= f.label :"住所" %>
+              <%= f.text_field :address %>
+            </div>
+            <div class="field form-group col-xs-11">
+              <%= f.label :"宛名" %>
+              <%= f.text_field :name %>
+            </div>
+          </div>
+
+          <div class="btns col-xs-8">
+             <!--ユーザーのカート画面に戻るパスを指定-->
+             カートへ戻る
+            
+            <%= f.submit "確認画面へ進む" %>
+            <% end %>
+          </div>
+    </div>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -1,0 +1,71 @@
+<h1>注文履歴詳細</h1>
+
+<h2 class="head-line title_h2 text-center">注文履歴詳細</h2>
+<div calss="row">
+  <% if @order.present? %>
+    <div class="col-xs-8">
+    <strong><i class="far fa-user"></i>注文情報</strong>
+  	<table>
+          <tbody>
+              <tr>
+                <th class="info">注文日</th>
+          	  <td class="text-left"><%= @order.created_at.strftime('%Y/%m/%d') %></td>
+              </tr>
+              <tr>
+              　<th class="info">配送先</th>
+                <td class="text-left"><%= @order.postal_code %><br>
+                	  <%= @order.address %><br>
+                	  <%= @order.name %>
+                </td>
+              </tr>
+              <tr>
+              　<th class="info">支払方法</th>
+                <td class="text-left"><%= @order.payment_method %></td>
+              </tr>
+              <tr>
+                <th class="info">ステータス</th>
+                <td class="text-left"><%= @order.order_status %></td>
+              </tr>
+          </tbody>
+        </table>
+    </div>
+
+    <div class="col-xs-3 col-xs-offset-1 billing">
+      <strong><i class="fas fa-yen-sign"></i>請求情報</strong>
+        	<table class="table table-bordered table-condensed">
+            <tr>
+              <th class="info">商品合計</th>
+              <td class="text-right col-xs-5"><円</td>
+            </tr>
+            <tr>
+              <th class="info">配送料</th>
+              <td class="text-right col-xs-5">円</td>
+            </tr>
+            <tr>
+              <th class="info">ご請求金額</th>
+              <td class="text-right col-xs-5">円</td>
+            </tr>
+        </table>
+    </div>
+    <div class="col-xs-7 order-details">
+    	<strong><i class="fas fa-store"></i>注文内容</strong>
+        <table class="table table-striped table-bordered table-condensed">
+        	<thead>
+  	      <tr class="info">
+  	      	<th>商品</th>
+  	        <th>単価(税込)</th>
+  	      	<th>個数</th>
+  	      	<th>小計</th>
+  	      </tr>
+        	</thead>
+        </table>
+    </div>
+    <% if customer_signed_in? %>
+      <%= link_to "注文履歴一覧へ戻る", customers_orders_path, class: "btn btn-info btn-lg order-index-back" %>
+    <% else %>
+      <%= link_to "会員詳細へ戻る", admin_customer_path, class: "btn btn-info order-index-back" %>
+    <% end %>
+  <% else %>
+    <p>注文履歴がありません。</p>
+  <% end %>
+</div>

--- a/app/views/public/orders/thanx.html.erb
+++ b/app/views/public/orders/thanx.html.erb
@@ -1,0 +1,7 @@
+<h1>ありがとうございました！</h1>
+<div class="row col-xs-12 center-block">
+  <h1 class="text-center ">ご購入ありがとうございました！</h1><br>
+  <div class="col-xs-7">
+    <%= link_to "　注文履歴はこちら　", "#" , class: "glyphicon glyphicon-folder-open btn btn-info pull-right" %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,9 @@ module Naganocake
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+ #enumを日本語にする定義
+  config.i18n.default_locale = :ja
+  config.i18n.load_path += Dir[Rails.root.join('config/locales/*.yml').to_s]
   end
+  
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,6 @@
+ ja:
+  enums:
+   order:
+    payment_method:
+     credit_card: "クレジットカード"
+     transfer: "銀行振込"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ devise_for :customers, controllers: {
   get "/about" => "homes#about"
   resources :items, only: [:index, :show]
   resources :customers, only: [:show, :edit, :update]
-  resources :orders, only: [:new, :index, :show, :create]
+  resources :orders, only: [:new, :index, :show, :create ,:thanx]
   resources :shipping_addresses, only: [:index, :edit, :create, :update, :destroy]
   resources :cart_items, only: [:index, :create, :update, :destroy]
 

--- a/db/migrate/20230119043641_create_orders.rb
+++ b/db/migrate/20230119043641_create_orders.rb
@@ -1,0 +1,15 @@
+class CreateOrders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :orders do |t|
+    t.integer :payment_method
+    t.integer :postage
+    t.integer :billing_amount
+    t.integer :status
+    t.string :address_name
+    t.string :postal_code
+    t.string :address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230119044307_create_order_items.rb
+++ b/db/migrate/20230119044307_create_order_items.rb
@@ -1,0 +1,11 @@
+class CreateOrderItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :order_items do |t|
+    t.integer :quantity
+    t.integer :tax_included_price
+    t.integer :status
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_18_053734) do
+ActiveRecord::Schema.define(version: 2023_01_19_044307) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -74,6 +74,26 @@ ActiveRecord::Schema.define(version: 2023_01_18_053734) do
 
   create_table "genres", force: :cascade do |t|
     t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "order_items", force: :cascade do |t|
+    t.integer "quantity"
+    t.integer "tax_included_price"
+    t.integer "status"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.integer "payment_method"
+    t.integer "postage"
+    t.integer "billing_amount"
+    t.integer "status"
+    t.string "address_name"
+    t.string "postal_code"
+    t.string "address"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/test/fixtures/order_items.yml
+++ b/test/fixtures/order_items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/orders.yml
+++ b/test/fixtures/orders.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/order_item_test.rb
+++ b/test/models/order_item_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class OrderItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class OrderTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
顧客の注文と注文履歴のページの作成を行いました。
以下、機能についてはまだ未実装のため、この後追加していきます

・注文時の金額と商品名の提示（item実装後に追加）
・届け先の自分の住所の選択
・登録済住所からの選択
・レイアウト調整

