### PR TITLE
Public 商品一覧/詳細情報表示機能の追加（仮）

### DIFF
--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -6,7 +6,8 @@ def index
 end
 
 def show
-  @item=Item.find(params[:id]).per
+  @item=Item.find(params[:id])
+  @item_quantity_array = (1..10)
 end
 
 private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,3 +1,10 @@
 class Item < ApplicationRecord
+  has_many :cart_item
+  has_many :order_item
   belongs_to :genre
+  
+  def add_tax_non_taxed_price
+    (self.non_taxed_price * 1.10).round    
+  end
+  
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
-  has_many :cart_item
-  has_many :order_item
+  has_many :cart_items
+  has_many :order_items
   belongs_to :genre
   
   def add_tax_non_taxed_price

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,23 +1,21 @@
 <div class="container">
-  <div class="row">
-    <h3>商品一覧</h3>
-    <h5>（全<%= item.count %>件）</h5>
-  </div>
-  
-  <% items.each do |item| %>
-  <div class="d-flex flex-row flex-wrap">
-    <div class="row">
-      <div class="col flex-fill">
+  <div class="row mt-5">
+    <div class="col-2">
+      <!--ジャンル検索機能実装スペース-->
+    </div>
+    <div class="col-8">
+      <h3 class="d-inline font-weight-bold">商品一覧</h3>
+      <h5 class="d-inline align-text-bottom">（全<%= @items.count %>件）</h5>
+      <% @items.each do |item| %>
+      <div class="d-flex flex-row flex-wrap flex-fill">
         <%= link_to item_path(item.id) do %>
           <%= image_tag item.user.get_profile_image, size: "60x100" %>
         <% end %>
         <%= item.name %>
-        <%= item.non_taxed_price %>
+        <%= number_to_currency(@item.add_tax_non_taxed_price, unit: "¥", strip_insignificant_zeros: true) %>
       </div>
+      <% end %>
     </div>
   </div>
-  <% end %>
-  
-  <%= paginate items %>
-  
+  <%= paginate @items %>
 </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,0 +1,24 @@
+<div class="container">
+  <div class="row mt-5">
+    <div class="col-2">
+      <!--ジャンル検索機能実装スペース-->
+    </div>
+    <div class="col-3">
+      <%= image_tag @item.user.get_profile_image, size: "90x120" %>
+    </div>
+    <div class="col-5">
+      <%= @item.name %>
+      <%= @item.text %>
+      <div class="d-inline">
+        <h3 class="font-weight-bold"><%= number_to_currency(@item.add_tax_non_taxed_price, unit: "¥", strip_insignificant_zeros: true) %></h3>
+        <h5 class="align-text-bottom">（税込）</h5>
+      </div>
+      <div class="d-inline">
+        <%= form_with model: @item do |f| %>
+          <%= f.select :order_item_quantity, @item_quantity_array, placeholder: "個数選択" %>
+        <% end %>
+        <%= f.submit "カートに入れる", class: "btn btn-success" %>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
商品一覧/詳細情報表示機能を追加しました。
※1.商品一覧情報については、商品登録機能実装後にレイアウトや詳細ページ移動の調整を行います。
※2.商品詳細情報については、上記に加えてカート機能の大枠ができ次第、動作確認やレイアウト調整を行います。
※3.ジャンル検索機能は未実装。

（変更点）
・Itemモデルにhas_many, 税込表示するためのコードを追記
・Itemコントローラーのindex, showに関するコードを追記
・indexページを作成
・indexページを作成
